### PR TITLE
feat: add honeycomb-news-sentiment skill

### DIFF
--- a/honeycomb-news-sentiment/SKILL.md
+++ b/honeycomb-news-sentiment/SKILL.md
@@ -22,9 +22,10 @@ Analyze news sentiment regarding AI automation for specific job position tickers
 
 ## Usage
 
-You can use the included `scripts/sentiment.py` script to run the analysis:
+You can use the included `scripts/sentiment.py` script to run the analysis from the `honeycomb-news-sentiment` directory:
 
 ```bash
+cd honeycomb-news-sentiment
 python3 scripts/sentiment.py SWE
 ```
 

--- a/honeycomb-news-sentiment/SKILL.md
+++ b/honeycomb-news-sentiment/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: honeycomb-news-sentiment
+description: Search Google News RSS for AI automation related to a job ticker and return a sentiment score from -1 to +1. Use when evaluating a job position's AI automation risk or sentiment.
+license: Apache-2.0
+compatibility: Requires network access to Google News RSS
+allowed-tools: Bash(python:*)
+metadata:
+  author: aden-hive
+  version: "1.0"
+---
+
+# HoneyComb News Sentiment
+
+Analyze news sentiment regarding AI automation for specific job position tickers on the HoneyComb exchange. It queries Google News RSS and calculates a sentiment score indicating whether recent news points towards automation (negative for the job) or not (positive for the job).
+
+## How it works
+
+1. **Input**: A job ticker like `$SWE` (or just `SWE`).
+2. **Search**: Translates the ticker to a job title and queries Google News RSS for `"{job title} AI automation"`.
+3. **Analyze**: Parses the news headlines and descriptions.
+4. **Output**: Returns a sentiment score from -1 to +1, where -1 means highly negative regarding the job's future (high automation risk) and +1 means positive (low automation risk or AI augmenting the role positively).
+
+## Usage
+
+You can use the included `scripts/sentiment.py` script to run the analysis:
+
+```bash
+python3 scripts/sentiment.py SWE
+```
+
+### Response Format
+
+The script outputs a JSON object containing the sentiment analysis results:
+
+```json
+{
+  "ticker": "SWE",
+  "job_title": "Software Engineer",
+  "query": "Software Engineer AI automation",
+  "articles_analyzed": 10,
+  "sentiment_score": -0.45
+}
+```
+
+## Ticker Mapping
+
+The script includes a basic mapping of tickers to job titles:
+- `SWE` -> Software Engineer
+- `PM` -> Product Manager
+- `DATA` -> Data Scientist
+- `DESIGN` -> UI/UX Designer
+- `CPA` -> Accountant
+- `HR` -> Human Resources
+- `NURSE` -> Nurse
+- `TEACHER` -> Teacher

--- a/honeycomb-news-sentiment/SKILL.md
+++ b/honeycomb-news-sentiment/SKILL.md
@@ -39,7 +39,13 @@ The script outputs a JSON object containing the sentiment analysis results:
   "job_title": "Software Engineer",
   "query": "Software Engineer AI automation",
   "articles_analyzed": 10,
-  "sentiment_score": -0.45
+  "sentiment_score": -0.45,
+  "article_scores": [
+    {
+      "title": "Example Article Title",
+      "score": -0.45
+    }
+  ]
 }
 ```
 
@@ -54,3 +60,5 @@ The script includes a basic mapping of tickers to job titles:
 - `HR` -> Human Resources
 - `NURSE` -> Nurse
 - `TEACHER` -> Teacher
+- `TRADER` -> Financial Trader
+- `LAWYER` -> Lawyer

--- a/honeycomb-news-sentiment/scripts/sentiment.py
+++ b/honeycomb-news-sentiment/scripts/sentiment.py
@@ -4,7 +4,12 @@ import urllib.parse
 import urllib.request
 import json
 import re
-from xml.etree import ElementTree as ET
+
+try:
+    from defusedxml import ElementTree as ET
+except ImportError:
+    print(json.dumps({"error": "defusedxml not installed. Run: pip install defusedxml"}))
+    sys.exit(1)
 
 try:
     from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
@@ -13,7 +18,6 @@ except ImportError:
     sys.exit(1)
 
 def get_job_title(ticker):
-    ticker = ticker.replace('$', '').upper()
     mapping = {
         'SWE': 'Software Engineer',
         'PM': 'Product Manager',
@@ -28,10 +32,8 @@ def get_job_title(ticker):
     }
     return mapping.get(ticker, ticker)
 
-def analyze_article(title, description, job_title):
-    analyzer = SentimentIntensityAnalyzer()
-    
-    # 1. Provide VADER sentiment base (General NLP scoring)
+def analyze_article(title, description, job_title, analyzer):
+    # 1. Provide VADER sentiment base (General NLP scoring, pre-instantiated analyzer passed in)
     title_vader = analyzer.polarity_scores(title)['compound']
     desc_vader = analyzer.polarity_scores(description)['compound']
     
@@ -39,6 +41,8 @@ def analyze_article(title, description, job_title):
     vader_base = (title_vader * 2 + desc_vader) / 3
     
     text = f"{title} {title} {description}".lower()
+    tokens = re.findall(r'\b\w+\b', text)
+    words = set(tokens)
     
     # 2. Expanded keyword lists specifically for AI & Automation
     automation_negative = [
@@ -79,19 +83,29 @@ def analyze_article(title, description, job_title):
     context = job_context.get(job_title, {'negative': ['completely automated', 'replaced by robot'], 'positive': ['ai tool', 'tech assistant']})
     
     custom_score = 0
-    words = set(re.findall(r'\b\w+\b', text))
     
-    # We use exact phrase matching for list items that have multiple words, and word matching for single words.
+    # We use exact phrase matching for list items that have multiple words, and token-based word matching for single words.
     for phrase in automation_negative + context['negative']:
-        if phrase in text:
-            # title count twice, description once (since title is duplicated in text string)
-            occurrences = text.count(phrase)
-            custom_score -= (0.15 * occurrences)
+        phrase_l = phrase.lower()
+        if ' ' in phrase_l:
+            if phrase_l in text:
+                occurrences = text.count(phrase_l)
+                custom_score -= (0.15 * occurrences)
+        else:
+            if phrase_l in words:
+                occurrences = sum(1 for w in tokens if w == phrase_l)
+                custom_score -= (0.15 * occurrences)
             
     for phrase in automation_positive + context['positive']:
-        if phrase in text:
-            occurrences = text.count(phrase)
-            custom_score += (0.15 * occurrences)
+        phrase_l = phrase.lower()
+        if ' ' in phrase_l:
+            if phrase_l in text:
+                occurrences = text.count(phrase_l)
+                custom_score += (0.15 * occurrences)
+        else:
+            if phrase_l in words:
+                occurrences = sum(1 for w in tokens if w == phrase_l)
+                custom_score += (0.15 * occurrences)
             
     # Combine VADER NLP scoring (0.4 weight) + Custom Automation Rules (0.6 weight)
     final_score = (vader_base * 0.4) + (custom_score * 0.6)
@@ -103,17 +117,24 @@ def main():
         print(json.dumps({"error": "Please provide a ticker (e.g. $SWE)"}))
         sys.exit(1)
         
-    ticker = sys.argv[1]
+    raw_ticker = sys.argv[1]
+    ticker = raw_ticker.replace('$', '').upper()
     job_title = get_job_title(ticker)
     
     query = f"{job_title} AI automation"
     encoded_query = urllib.parse.quote_plus(query)
-    
     url = f"https://news.google.com/rss/search?q={encoded_query}&hl=en-US&gl=US&ceid=US:en"
+    
+    # Instantiate analyzer once to save expensive overhead
+    try:
+        analyzer = SentimentIntensityAnalyzer()
+    except Exception as e:
+        print(json.dumps({"error": f"Failed to initialize analyzer: {e}"}))
+        sys.exit(1)
     
     try:
         req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
-        with urllib.request.urlopen(req) as response:
+        with urllib.request.urlopen(req, timeout=10) as response:
             xml_data = response.read()
             
         root = ET.fromstring(xml_data)
@@ -125,10 +146,13 @@ def main():
         if channel is not None:
             items = channel.findall('item')
             for item in items[:10]: # Analyze top 10
-                title = item.find('title').text if item.find('title') is not None else ""
-                desc = item.find('description').text if item.find('description') is not None else ""
+                title_el = item.find('title')
+                desc_el = item.find('description')
                 
-                score = analyze_article(title, desc, job_title)
+                title = (title_el.text or "").strip() if title_el is not None else ""
+                desc = (desc_el.text or "").strip() if desc_el is not None else ""
+                
+                score = analyze_article(title, desc, job_title, analyzer)
                 total_score += score
                 articles.append({
                     "title": title,

--- a/honeycomb-news-sentiment/scripts/sentiment.py
+++ b/honeycomb-news-sentiment/scripts/sentiment.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+import sys
+import urllib.parse
+import urllib.request
+import json
+import re
+from xml.etree import ElementTree as ET
+
+try:
+    from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+except ImportError:
+    print(json.dumps({"error": "vaderSentiment not installed. Run: pip install vaderSentiment"}))
+    sys.exit(1)
+
+def get_job_title(ticker):
+    ticker = ticker.replace('$', '').upper()
+    mapping = {
+        'SWE': 'Software Engineer',
+        'PM': 'Product Manager',
+        'DATA': 'Data Scientist',
+        'DESIGN': 'UI/UX Designer',
+        'CPA': 'Accountant',
+        'HR': 'Human Resources',
+        'NURSE': 'Nurse',
+        'TEACHER': 'Teacher',
+        'TRADER': 'Financial Trader',
+        'LAWYER': 'Lawyer'
+    }
+    return mapping.get(ticker, ticker)
+
+def analyze_article(title, description, job_title):
+    analyzer = SentimentIntensityAnalyzer()
+    
+    # 1. Provide VADER sentiment base (General NLP scoring)
+    title_vader = analyzer.polarity_scores(title)['compound']
+    desc_vader = analyzer.polarity_scores(description)['compound']
+    
+    # TITLE gets 2x weight vs description
+    vader_base = (title_vader * 2 + desc_vader) / 3
+    
+    text = f"{title} {title} {description}".lower()
+    
+    # 2. Expanded keyword lists specifically for AI & Automation
+    automation_negative = [
+        'replace', 'automate', 'lost', 'obsolete', 'risk', 'threat', 'decline', 
+        'layoff', 'disruption', 'eliminate', 'downsize', 'redundant', 'taking over',
+        'job loss', 'unemployment', 'useless', 'displace', 'substitute', 'outsource',
+        'fewer jobs', 'threaten', 'extinct', 'vulnerable', 'end of', 'replacing',
+        'destroy', 'wipe out', 'job killers', 'take away'
+    ]
+    
+    automation_positive = [
+        'augment', 'help', 'assist', 'grow', 'create', 'opportunity', 'enhance', 'boost',
+        'collaborate', 'empower', 'productivity', 'accelerate', 'demand', 'hiring',
+        'new jobs', 'up-skill', 'upskill', 'evolution', 'valuable', 'tool', 'better',
+        'improve', 'efficiency', 'partner', 'leverage', 'benefit'
+    ]
+    
+    # 3. Job-specific context words (tuning for distinct jobs like SWE vs Nurse)
+    job_context = {
+        'Software Engineer': {
+            'negative': ['devin', 'AI software engineer', 'auto-generate code', 'gpt-4 coding', 'no-code', 'low-code', 'replace coders'],
+            'positive': ['copilot', 'pair programming', 'developer productivity', 'code review', 'faster development', 'github copilot']
+        },
+        'Nurse': {
+            'negative': ['robot nurse', 'automated diagnosis', 'replace staff'],
+            'positive': ['patient care', 'health tech', 'medical records assistance', 'triage tool', 'diagnostics support', 'reduce burnout']
+        },
+        'Data Scientist': {
+            'negative': ['auto-ml', 'automated insights', 'replace analysts'],
+            'positive': ['advanced modeling', 'data crunching', 'better predictions', 'scale analysis']
+        },
+        'Teacher': {
+            'negative': ['ai tutor replacement', 'automated grading replacing'],
+            'positive': ['personalized learning', 'classroom assistant', 'lesson planning tool', 'edtech']
+        }
+    }
+    
+    context = job_context.get(job_title, {'negative': ['completely automated', 'replaced by robot'], 'positive': ['ai tool', 'tech assistant']})
+    
+    custom_score = 0
+    words = set(re.findall(r'\b\w+\b', text))
+    
+    # We use exact phrase matching for list items that have multiple words, and word matching for single words.
+    for phrase in automation_negative + context['negative']:
+        if phrase in text:
+            # title count twice, description once (since title is duplicated in text string)
+            occurrences = text.count(phrase)
+            custom_score -= (0.15 * occurrences)
+            
+    for phrase in automation_positive + context['positive']:
+        if phrase in text:
+            occurrences = text.count(phrase)
+            custom_score += (0.15 * occurrences)
+            
+    # Combine VADER NLP scoring (0.4 weight) + Custom Automation Rules (0.6 weight)
+    final_score = (vader_base * 0.4) + (custom_score * 0.6)
+    
+    return max(min(final_score, 1.0), -1.0)
+
+def main():
+    if len(sys.argv) < 2:
+        print(json.dumps({"error": "Please provide a ticker (e.g. $SWE)"}))
+        sys.exit(1)
+        
+    ticker = sys.argv[1]
+    job_title = get_job_title(ticker)
+    
+    query = f"{job_title} AI automation"
+    encoded_query = urllib.parse.quote_plus(query)
+    
+    url = f"https://news.google.com/rss/search?q={encoded_query}&hl=en-US&gl=US&ceid=US:en"
+    
+    try:
+        req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+        with urllib.request.urlopen(req) as response:
+            xml_data = response.read()
+            
+        root = ET.fromstring(xml_data)
+        
+        articles = []
+        total_score = 0
+        
+        channel = root.find('channel')
+        if channel is not None:
+            items = channel.findall('item')
+            for item in items[:10]: # Analyze top 10
+                title = item.find('title').text if item.find('title') is not None else ""
+                desc = item.find('description').text if item.find('description') is not None else ""
+                
+                score = analyze_article(title, desc, job_title)
+                total_score += score
+                articles.append({
+                    "title": title,
+                    "score": round(score, 3)
+                })
+                
+        avg_score = total_score / len(articles) if articles else 0
+        
+        result = {
+            "ticker": ticker,
+            "job_title": job_title,
+            "query": query,
+            "articles_analyzed": len(articles),
+            "sentiment_score": round(max(min(avg_score, 1.0), -1.0), 3),
+            "article_scores": articles
+        }
+        print(json.dumps(result, indent=2))
+        
+    except Exception as e:
+        print(json.dumps({"error": str(e)}))
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #1 

## What this adds
New skill: `honeycomb-news-sentiment`

Fetches real-time Google News RSS for any HoneyComb 
job ticker and returns an AI automation sentiment score.

## Usage
./scripts/sentiment.py SWE

## Output
{
  "ticker": "SWE",
  "sentiment_score": -0.002,
  "articles_analyzed": 10,
  "article_scores": [...]
}

## Tested on
- $SWE → -0.002 (slightly negative, AI threat growing)
- $NURSE → -0.015 (slightly negative, mixed signals)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AI-automation sentiment analysis tool that accepts a job ticker, maps it to a job title, queries news for "<job title> AI automation", analyzes up to the top articles, and returns a per-article and overall sentiment score from -1 to +1.

* **Documentation**
  * Added usage instructions, I/O schema, required network/tooling notes, and example ticker-to-job-title mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->